### PR TITLE
increase default jvm max heap size to 4gb to prevent out of memory

### DIFF
--- a/packer_images/jvm.options
+++ b/packer_images/jvm.options
@@ -4,7 +4,7 @@
 # Xmx represents the maximum size of total heap space
 
 -Xms1g
--Xmx2g
+-Xmx4g
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
on the initial indexing of large amount of cases