### PR TITLE
Allow healthcheck from outside the VM

### DIFF
--- a/packer_images/logstash.yml
+++ b/packer_images/logstash.yml
@@ -187,7 +187,7 @@ dead_letter_queue.max_bytes: 1024mb
 #
 # Bind address for the metrics REST endpoint
 #
-# http.host: "127.0.0.1"
+http.host: "0.0.0.0"
 #
 # Bind port for the metrics REST endpoint, this option also accept a range
 # (9600-9700) and logstash will pick up the first available ports.


### PR DESCRIPTION
We listen on 0.0.0.0 and rely on NSG rules to limit access to the
healthcheck.