### PR TITLE
RDM-12686 adjust GlobalSearch properties

### DIFF
--- a/packer_images/ccd_logstash.conf.in
+++ b/packer_images/ccd_logstash.conf.in
@@ -106,7 +106,7 @@ filter{
                rename => {"[data_classification][caseManagementCategory]" => "[data_classification_new][caseManagementCategory]" }
             }
         }
-        mutate { remove_field =>[ "data" ,"supplementary_data", "data_classification", "last_state_modified_date", "type","last_modified", "created_date" ] }
+        mutate { remove_field =>[ "data" ,"supplementary_data", "data_classification", "last_state_modified_date", "type" ] }
 
         mutate {
                 rename => { "[data_new]" => "data" }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-12686](https://tools.hmcts.net/jira/browse/RDM-12686) _"Establish the new Global Search endpoint"_

### Change description ###

Adjust GlobalSearch properties: reinstate `created_date` & `last_modified` to allow them to be searched against, as `created_date` is the default sort for GlobalSearch.


NB: this PR points to the branch used by #91

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
